### PR TITLE
Use Chef::ApiClientV1 instead of Chef::ApiClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,4 +150,3 @@ Running Sushi has no notion of cookbook dependencies and uploads all cookbooks i
 ## Limitations
 
 * Running Sushi does not check if two (node, environment, role) names are the same but the .json files are different. This should be controlled with Git hooks or similar
-* Currently Running Sushi only supports Chef Server 11 as Chef Server 12 has introduced breaking changes with regards to node preseeding

--- a/bin/running-sushi
+++ b/bin/running-sushi
@@ -355,6 +355,7 @@ def setup_config
   Chef::Config[:node_name] = ChefDelivery::Config.user
   Chef::Config[:client_key] = ChefDelivery::Config.pem
   Chef::Config[:chef_server_url] = ChefDelivery::Config.chef_server_url
+  Chef::Config[:ssl_verify_mode] = ChefDelivery::Config.ssl_verify_mode || :verify_peer
 end
 
 def get_repo

--- a/running_sushi.gemspec
+++ b/running_sushi.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'running_sushi'
-  s.version = '0.6.0'
+  s.version = '0.7.0'
   s.platform = Gem::Platform::RUBY
   s.summary = 'Running Sushi'
   s.description = 'Utility for keeping Chef servers in sync with a repo'


### PR DESCRIPTION
* This patch removes support for chef11 client
* Removes old info about chef12 server.

Chef::ApiClient is deprecated and will be replaced by Chef::ApiClientV1:
https://github.com/chef/chef/blob/master/lib/chef/api_client.rb#L32
